### PR TITLE
Check youtube-dl GPG signature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM alpine:3.4
 
 RUN set -x \
- && apk add --no-cache ca-certificates curl ffmpeg python \
+ && apk add --no-cache ca-certificates curl ffmpeg python gnupg \
     # Install youtube-dl
     # https://github.com/rg3/youtube-dl
  && curl -Lo /usr/local/bin/youtube-dl https://yt-dl.org/downloads/latest/youtube-dl \
+ && curl -Lo youtube-dl.sig https://yt-dl.org/downloads/latest/youtube-dl.sig \
+ && gpg --keyserver keyserver.ubuntu.com --recv-keys '7D33D762FD6C35130481347FDB4B54CBA4826A18' \
+ && gpg --keyserver keyserver.ubuntu.com --recv-keys 'ED7F5BF46B3BBED81C87368E2C393E0F18A9236D' \
+ && gpg --verify youtube-dl.sig /usr/local/bin/youtube-dl \
  && chmod a+rx /usr/local/bin/youtube-dl \
     # Clean-up
- && apk del curl \
+ && rm youtube-dl.sig \
+ && apk del curl gnupg \
     # Create directory to hold downloads.
  && mkdir /downloads \
  && chmod a+rw /downloads \


### PR DESCRIPTION
This pull request changes the Dockerfile so that the youtube-dl GPG signature is checked when building the image.

The GPG keys added are those of Philipp Hagemeister and Sergey M. which are listed on the [download page for youtube-dl](http://rg3.github.io/youtube-dl/download.html).
