### PR TITLE
Create a .cache  in / (=~) with 0777 mode as newer version youtube-dl require to write in ~/.cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN set -x \
  && mkdir /downloads \
  && chmod a+rw /downloads \
     # Basic check it works.
- && youtube-dl --version
+ && youtube-dl --version \
+ && mkdir /.cache \
+ && chmod 777 /.cache
 
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
I tried to use the tool on a youtube page, and it failed (while strangely other pages works) with a regexp error.

So I tried to build the image in order to have the lastest version (it appears the regexp problem is not on the latest version). But it failed because latest version seems to store informations in ~/.cache (which tries to store that in /.cache due to $HOME being /) which fails because when run as user, there is no right to create /.cache

This PR fixed that problem